### PR TITLE
Add Magnitude method to Vector type

### DIFF
--- a/features/magnitude.feature
+++ b/features/magnitude.feature
@@ -1,0 +1,39 @@
+Feature: Calculate vector magnitude
+  As a developer
+  I want to calculate the magnitude of vectors
+  So that I can determine their length
+
+  Scenario: Calculate magnitude of a 2D vector
+    Given vector a is
+      | 3.0 |
+      | 4.0 |
+    When I calculate the magnitude of vector a
+    Then the result should be 5.0
+
+  Scenario: Calculate magnitude of a zero vector
+    Given vector a is
+      | 0.0 |
+      | 0.0 |
+    When I calculate the magnitude of vector a
+    Then the result should be 0.0
+
+  Scenario: Calculate magnitude of a single component vector
+    Given vector a is
+      | 5.0 |
+    When I calculate the magnitude of vector a
+    Then the result should be 5.0
+
+  Scenario: Calculate magnitude of a 3D vector
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+      | 2.0 |
+    When I calculate the magnitude of vector a
+    Then the result should be 3.0
+
+  Scenario: Calculate magnitude of a negative component vector
+    Given vector a is
+      | -3.0 |
+      | -4.0 |
+    When I calculate the magnitude of vector a
+    Then the result should be 5.0

--- a/magnitude.go
+++ b/magnitude.go
@@ -1,0 +1,12 @@
+package vectors
+
+import "math"
+
+// Magnitude returns the length (magnitude) of the vector.
+func (v Vector) Magnitude() float64 {
+	sumOfSquares := 0.0
+	for _, component := range v {
+		sumOfSquares += component * component
+	}
+	return math.Sqrt(sumOfSquares)
+}

--- a/magnitude_test.go
+++ b/magnitude_test.go
@@ -1,0 +1,21 @@
+package vectors
+
+import (
+	"context"
+	"errors"
+	"github.com/cucumber/godog"
+)
+
+func iCalculateMagnitudeOfVector(key any) func(ctx context.Context) (context.Context, error) {
+	return func(ctx context.Context) (context.Context, error) {
+		v, ok := ctx.Value(key).(Vector)
+		if !ok {
+			return ctx, errors.New("vector not found in context")
+		}
+		return context.WithValue(ctx, resultKey{}, v.Magnitude()), nil
+	}
+}
+
+func initializeMagnitudeScenario(ctx *godog.ScenarioContext) {
+	ctx.Step(`^I calculate the magnitude of vector a$`, iCalculateMagnitudeOfVector(aKey{}))
+}

--- a/vectors_test.go
+++ b/vectors_test.go
@@ -103,6 +103,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	initializeNormalizeScenario(ctx)
 	initializeIsNormalizedScenario(ctx)
 	initializeEqualsScenario(ctx)
+	initializeMagnitudeScenario(ctx)
 }
 
 func TestFeatures(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `Magnitude()` method to the `Vector` type that calculates and returns the Euclidean length of a vector
- Implementation uses the standard formula: √(Σx²) where x represents each component
- Follows existing codebase patterns with comprehensive BDD tests using Cucumber/godog

## Test plan
- [x] All existing tests pass
- [x] 5 new BDD test scenarios covering:
  - 2D vector magnitude (3,4 → 5)
  - Zero vector magnitude (0,0 → 0)
  - Single component vector (5 → 5)
  - 3D vector magnitude (1,2,2 → 3)
  - Negative component vector (-3,-4 → 5)
- [x] Method follows the same structure and conventions as existing vector methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)