### PR TITLE
Add distance metrics: Euclidean, Negative Inner Product, and Taxicab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,165 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Building and Testing
+```bash
+# Build the project
+go build -v ./...
+
+# Run all tests (includes BDD feature tests)
+go test -v ./...
+```
+
+### Pre-commit Hooks
+This project uses pre-commit hooks. After making changes, the following automatically run:
+- `go-fmt` - Format Go code
+- `golangci-lint` - Lint Go code
+- `go-unit-tests` - Run unit tests
+- `go-mod-tidy` - Tidy Go modules
+- `commitlint` - Enforce conventional commits
+- `reformat-gherkin` - Format .feature files
+
+To manually run pre-commit on all files:
+```bash
+pre-commit run --all-files
+```
+
+## Architecture Overview
+
+### Core Design
+This is a Go library providing vector mathematics operations. The architecture follows these principles:
+
+- **Type Definition**: `Vector []float64` - vectors are slices of float64
+- **Receiver Methods**: Operations implemented as methods on the Vector type (e.g., `v.Magnitude()`, `v.Normalize()`)
+- **Error Handling**: Operations that can fail return `(result, error)` tuples (e.g., `CosineSimilarity` returns error for zero vectors)
+- **BDD Testing**: Comprehensive test coverage using Cucumber/godog with Gherkin feature files
+
+### File Organization Pattern
+Each vector operation follows this structure:
+- `operation.go` - Implementation file with the method/function
+- `operation_test.go` - BDD test step definitions and scenario initialization
+- `features/operation.feature` - Gherkin feature file with test scenarios
+
+Example for the Magnitude operation:
+- `magnitude.go` - Contains `func (v Vector) Magnitude() float64`
+- `magnitude_test.go` - Contains `iCalculateMagnitudeOfVector()` and `initializeMagnitudeScenario()`
+- `features/magnitude.feature` - Contains BDD test scenarios
+
+### BDD Testing Structure
+Tests use a shared context pattern defined in `vectors_test.go`:
+
+```go
+type aKey struct{}      // Context key for first vector
+type bKey struct{}      // Context key for second vector
+type resultKey struct{} // Context key for operation result
+type errKey struct{}    // Context key for errors
+```
+
+All scenario initializers must be registered in `InitializeScenario()` in `vectors_test.go`.
+
+Shared helper functions:
+- `convertTableToVector()` - Converts Gherkin tables to Vector type
+- `vectorIs()` - Step definition factory for "Given vector X is" steps
+- `theResultShouldBe()` - Assertion for float64 results
+- `theResultShouldBeVector()` - Assertion for Vector results
+- `theResultShouldBeBool()` - Assertion for boolean results
+- `theResultShouldBeAnError()` - Assertion for error results
+
+## Adding New Vector Operations
+
+When adding a new operation, follow this pattern:
+
+1. **Create implementation file** (e.g., `newoperation.go`):
+   ```go
+   package vectors
+
+   func (v Vector) NewOperation() ResultType {
+       // implementation
+   }
+   ```
+
+2. **Create test file** (e.g., `newoperation_test.go`):
+   ```go
+   package vectors
+
+   import (
+       "context"
+       "errors"
+       "github.com/cucumber/godog"
+   )
+
+   func iPerformNewOperation(key any) func(ctx context.Context) (context.Context, error) {
+       return func(ctx context.Context) (context.Context, error) {
+           v, ok := ctx.Value(key).(Vector)
+           if !ok {
+               return ctx, errors.New("vector not found in context")
+           }
+           return context.WithValue(ctx, resultKey{}, v.NewOperation()), nil
+       }
+   }
+
+   func initializeNewOperationScenario(ctx *godog.ScenarioContext) {
+       ctx.Step(`^I perform new operation on vector a$`, iPerformNewOperation(aKey{}))
+   }
+   ```
+
+3. **Create feature file** (`features/newoperation.feature`):
+   ```gherkin
+   Feature: New Operation
+     As a developer
+     I want to perform new operation on vectors
+     So that I can achieve specific goal
+
+     Scenario: Description of test case
+       Given vector a is
+         | 1.0 |
+         | 2.0 |
+       When I perform new operation on vector a
+       Then the result should be <expected>
+   ```
+
+4. **Register the scenario initializer** in `vectors_test.go`:
+   ```go
+   func InitializeScenario(ctx *godog.ScenarioContext) {
+       initializeSharedSteps(ctx)
+       // ... existing initializers ...
+       initializeNewOperationScenario(ctx) // Add this line
+   }
+   ```
+
+## Special Considerations
+
+### Floating Point Precision
+When comparing floating point values for equality (e.g., checking if a vector is normalized), use epsilon comparison:
+```go
+const epsilon = 1e-9
+if math.Abs(value - expected) < epsilon { ... }
+```
+
+### Zero Vector Handling
+- `Normalize()` returns the zero vector unchanged (no error)
+- `CosineSimilarity()` returns an error for zero vectors
+- Consider edge cases carefully when implementing new operations
+
+### Commit Message Format
+This project uses Conventional Commits. Format your commits as:
+```
+<type>: <description>
+
+[optional body]
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+Types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, etc.
+
+### Pull Request Requirements
+Before creating a PR, ensure:
+- Branch has been rebased with the target branch (usually `dev`)
+- TDD has been applied with BDD feature tests
+- All linters pass
+- Documentation added to godoc and/or README.md
+- Pre-commit hooks pass

--- a/README.md
+++ b/README.md
@@ -1,22 +1,368 @@
 # vectors
-Support for vectors
+
+A lightweight Go library for vector mathematics operations, designed for machine learning and computational geometry applications.
 
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/SPANDigital/vectors)
 ![Dev Go Action Workflow Status](https://img.shields.io/github/actions/workflow/status/spandigital/vectors/go.yml?branch=dev&label=dev)
 ![Main Go Action Workflow Status](https://img.shields.io/github/actions/workflow/status/spandigital/vectors/go.yml?branch=main&label=main)
 ![Tag](https://img.shields.io/github/v/tag/SPANDigital/vectors)
+[![Go Reference](https://pkg.go.dev/badge/github.com/spandigital/vectors.svg)](https://pkg.go.dev/github.com/spandigital/vectors)
 
-## Alias
+## Features
 
-Vector is an alias for a slice of floats
+- **Magnitude**: Calculate the Euclidean length of vectors
+- **Normalization**: Convert vectors to unit length
+- **Cosine Similarity**: Measure similarity between vectors
+- **Euclidean Distance**: Calculate straight-line distance between vectors
+- **Negative Inner Product**: Calculate negative dot product as a distance metric
+- **Taxicab Distance**: Calculate Manhattan/L1 distance between vectors
+- **Equality Checking**: Compare vectors for equality
+- **Normalization Verification**: Check if a vector is already normalized
+- **BDD Test Coverage**: Comprehensive behavioral tests with Cucumber/godog
+
+## Installation
+
+```bash
+go get github.com/spandigital/vectors
 ```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/spandigital/vectors"
+)
+
+func main() {
+    // Create a vector
+    v := vectors.Vector{3.0, 4.0}
+
+    // Calculate magnitude
+    magnitude := v.Magnitude()
+    fmt.Printf("Magnitude: %.2f\n", magnitude) // Output: Magnitude: 5.00
+
+    // Normalize the vector
+    normalized := v.Normalize()
+    fmt.Printf("Normalized: %v\n", normalized) // Output: Normalized: [0.6 0.8]
+
+    // Check if normalized
+    isNorm := normalized.IsNormalized()
+    fmt.Printf("Is normalized: %t\n", isNorm) // Output: Is normalized: true
+
+    // Calculate cosine similarity
+    v2 := vectors.Vector{1.0, 2.0}
+    similarity, err := vectors.CosineSimilarity(v, v2)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("Cosine similarity: %.4f\n", similarity)
+
+    // Calculate Euclidean distance
+    distance, err := vectors.EuclideanDistance(v, v2)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("Euclidean distance: %.2f\n", distance)
+}
+```
+
+## API Reference
+
+### Type Definition
+
+```go
 type Vector []float64
 ```
 
-## Functions
+Vector is an alias for a slice of float64 values, representing an n-dimensional vector.
 
-### Cosine Similarity
+### Methods
+
+#### Magnitude
+
+```go
+func (v Vector) Magnitude() float64
+```
+
+Returns the Euclidean length (magnitude) of the vector using the formula: √(Σx²)
+
+**Example:**
+```go
+v := vectors.Vector{3.0, 4.0}
+magnitude := v.Magnitude() // Returns 5.0
+
+v2 := vectors.Vector{1.0, 2.0, 2.0}
+magnitude2 := v2.Magnitude() // Returns 3.0
+```
+
+#### Normalize
+
+```go
+func (v Vector) Normalize() Vector
+```
+
+Returns a new vector with the same direction but unit length (magnitude of 1.0). If the vector is a zero vector, it returns the zero vector unchanged.
+
+**Example:**
+```go
+v := vectors.Vector{3.0, 4.0}
+normalized := v.Normalize() // Returns [0.6, 0.8]
+
+zero := vectors.Vector{0.0, 0.0}
+normalizedZero := zero.Normalize() // Returns [0.0, 0.0]
+```
+
+#### IsNormalized
+
+```go
+func (v Vector) IsNormalized() bool
+```
+
+Checks whether the vector has unit length (magnitude of 1.0). Uses epsilon comparison (1e-9) for floating-point precision.
+
+**Example:**
+```go
+v := vectors.Vector{0.6, 0.8}
+isNorm := v.IsNormalized() // Returns true
+
+v2 := vectors.Vector{3.0, 4.0}
+isNorm2 := v2.IsNormalized() // Returns false
+```
+
+#### Equals
+
+```go
+func (a Vector) Equals(b Vector) bool
+```
+
+Compares two vectors for exact equality. Returns false if vectors have different lengths or any components differ.
+
+**Example:**
+```go
+v1 := vectors.Vector{1.0, 2.0, 3.0}
+v2 := vectors.Vector{1.0, 2.0, 3.0}
+v3 := vectors.Vector{1.0, 2.0}
+
+v1.Equals(v2) // Returns true
+v1.Equals(v3) // Returns false (different lengths)
+```
+
+### Functions
+
+#### CosineSimilarity
+
+```go
+func CosineSimilarity(a Vector, b Vector) (float64, error)
+```
+
+Calculates the cosine similarity between two vectors. Returns a value between -1.0 and 1.0, where:
+- 1.0 indicates identical direction
+- 0.0 indicates orthogonal vectors
+- -1.0 indicates opposite direction
+
+Returns an error if either vector is a zero vector.
+
+**Example:**
+```go
+v1 := vectors.Vector{1.0, 2.0, 3.0}
+v2 := vectors.Vector{4.0, 5.0, 6.0}
+
+similarity, err := vectors.CosineSimilarity(v1, v2)
+if err != nil {
+    // Handle error (e.g., zero vector)
+    panic(err)
+}
+fmt.Printf("Similarity: %.4f\n", similarity)
+
+// Identical vectors
+v3 := vectors.Vector{1.0, 0.0}
+similarity2, _ := vectors.CosineSimilarity(v3, v3) // Returns 1.0
+
+// Orthogonal vectors
+v4 := vectors.Vector{1.0, 0.0}
+v5 := vectors.Vector{0.0, 1.0}
+similarity3, _ := vectors.CosineSimilarity(v4, v5) // Returns 0.0
+```
+
+#### EuclideanDistance
+
+```go
+func EuclideanDistance(a Vector, b Vector) (float64, error)
+```
+
+Calculates the Euclidean distance (straight-line distance) between two vectors using the formula: √(Σ(ai - bi)²)
+
+Returns an error if the vectors have different lengths.
+
+**Example:**
+```go
+v1 := vectors.Vector{1.0, 2.0}
+v2 := vectors.Vector{4.0, 6.0}
+
+distance, err := vectors.EuclideanDistance(v1, v2)
+if err != nil {
+    panic(err)
+}
+fmt.Printf("Distance: %.1f\n", distance) // Returns 5.0
+
+// Identical vectors have zero distance
+v3 := vectors.Vector{1.0, 2.0, 3.0}
+distance2, _ := vectors.EuclideanDistance(v3, v3) // Returns 0.0
+
+// Distance from origin
+origin := vectors.Vector{0.0, 0.0, 0.0}
+point := vectors.Vector{1.0, 2.0, 2.0}
+distance3, _ := vectors.EuclideanDistance(origin, point) // Returns 3.0
+```
+
+#### NegativeInnerProduct
+
+```go
+func NegativeInnerProduct(a Vector, b Vector) (float64, error)
+```
+
+Calculates the negative inner product (negative dot product) between two vectors using the formula: -(Σ(ai * bi))
+
+This is commonly used as a distance metric in machine learning and information retrieval. Returns an error if the vectors have different lengths.
+
+**Example:**
+```go
+v1 := vectors.Vector{1.0, 2.0, 3.0}
+v2 := vectors.Vector{4.0, 5.0, 6.0}
+
+product, err := vectors.NegativeInnerProduct(v1, v2)
+if err != nil {
+    panic(err)
+}
+fmt.Printf("Negative inner product: %.1f\n", product) // Returns -32.0
+
+// Orthogonal vectors have zero inner product
+v3 := vectors.Vector{1.0, 0.0}
+v4 := vectors.Vector{0.0, 1.0}
+product2, _ := vectors.NegativeInnerProduct(v3, v4) // Returns 0.0
+
+// With negative components
+v5 := vectors.Vector{-1.0, 2.0}
+v6 := vectors.Vector{3.0, -4.0}
+product3, _ := vectors.NegativeInnerProduct(v5, v6) // Returns 11.0
+```
+
+#### TaxicabDistance
+
+```go
+func TaxicabDistance(a Vector, b Vector) (float64, error)
+```
+
+Calculates the taxicab distance (Manhattan distance, L1 distance) between two vectors using the formula: Σ|ai - bi|
+
+This metric represents the distance when only axis-aligned movement is allowed. Returns an error if the vectors have different lengths.
+
+**Example:**
+```go
+v1 := vectors.Vector{1.0, 2.0}
+v2 := vectors.Vector{4.0, 6.0}
+
+distance, err := vectors.TaxicabDistance(v1, v2)
+if err != nil {
+    panic(err)
+}
+fmt.Printf("Taxicab distance: %.1f\n", distance) // Returns 7.0
+
+// Distance from origin
+origin := vectors.Vector{0.0, 0.0, 0.0}
+point := vectors.Vector{1.0, 2.0, 3.0}
+distance2, _ := vectors.TaxicabDistance(origin, point) // Returns 6.0
+
+// With negative components
+v3 := vectors.Vector{-1.0, -2.0}
+v4 := vectors.Vector{2.0, 3.0}
+distance3, _ := vectors.TaxicabDistance(v3, v4) // Returns 8.0
+```
+
+## Development
+
+### Prerequisites
+
+- Go 1.22.2 or later
+- Pre-commit hooks (optional but recommended)
+
+### Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/SPANDigital/vectors.git
+cd vectors
+
+# Install dependencies
+go mod download
+
+# Install pre-commit hooks (optional)
+pre-commit install
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+go test -v ./...
+
+# Run tests with coverage
+go test -v -cover ./...
+```
+
+The project uses Behavior-Driven Development (BDD) with Cucumber/godog. Feature files are located in the `features/` directory.
+
+### Building
+
+```bash
+go build -v ./...
+```
+
+### Code Quality
+
+This project uses pre-commit hooks to ensure code quality:
+- **go-fmt**: Automatic code formatting
+- **golangci-lint**: Comprehensive linting
+- **go-unit-tests**: Automatic test execution
+- **go-mod-tidy**: Dependency management
+- **commitlint**: Conventional commit message validation
+- **reformat-gherkin**: Feature file formatting
+
+## Contributing
+
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on:
+- Code of Conduct
+- Development workflow
+- Pull request process
+- Testing requirements
+
+### Commit Messages
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/). Format your commits as:
 
 ```
-func CosineSimilarity(a Vector, b Vector) (cosine float64, err error)
+<type>: <description>
+
+[optional body]
+
+[optional footer]
 ```
+
+Types: `feat`, `fix`, `docs`, `test`, `chore`, `refactor`, `style`, `perf`
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/SPANDigital/vectors/issues)
+- **Security**: See [SECURITY.md](SECURITY.md) for reporting vulnerabilities
+- **Contact**: richard.wooding@spandigital.com
+
+## Acknowledgments
+
+Developed by [Span Digital](https://github.com/SPANDigital) with comprehensive test coverage using Cucumber/godog for behavior-driven development.

--- a/euclideandistance.go
+++ b/euclideandistance.go
@@ -1,0 +1,23 @@
+package vectors
+
+import (
+	"errors"
+	"math"
+)
+
+// EuclideanDistance calculates the Euclidean distance between two vectors.
+// It returns an error if the vectors have different lengths.
+// The Euclidean distance is the straight-line distance between two points: √(Σ(ai - bi)²)
+func EuclideanDistance(a Vector, b Vector) (float64, error) {
+	if len(a) != len(b) {
+		return 0.0, errors.New("vectors must have the same length")
+	}
+
+	sumOfSquares := 0.0
+	for i := range len(a) {
+		diff := a[i] - b[i]
+		sumOfSquares += diff * diff
+	}
+
+	return math.Sqrt(sumOfSquares), nil
+}

--- a/euclideandistance_test.go
+++ b/euclideandistance_test.go
@@ -1,0 +1,28 @@
+package vectors
+
+import (
+	"context"
+	"github.com/cucumber/godog"
+)
+
+func iCalculateTheEuclideanDistance(ctx context.Context) (context.Context, error) {
+	a, ok := ctx.Value(aKey{}).(Vector)
+	if !ok {
+		return ctx, nil
+	}
+	b, ok := ctx.Value(bKey{}).(Vector)
+	if !ok {
+		return ctx, nil
+	}
+
+	distance, err := EuclideanDistance(a, b)
+	if err != nil {
+		return context.WithValue(ctx, errKey{}, err), nil
+	}
+
+	return context.WithValue(ctx, resultKey{}, distance), nil
+}
+
+func initializeEuclideanDistanceScenario(ctx *godog.ScenarioContext) {
+	ctx.Step(`^I calculate the Euclidean distance$`, iCalculateTheEuclideanDistance)
+}

--- a/features/euclideandistance.feature
+++ b/features/euclideandistance.feature
@@ -1,0 +1,57 @@
+Feature: Calculate Euclidean distance
+  As a developer
+  I want to calculate the Euclidean distance between vectors
+  So that I can measure the straight-line distance between points
+
+  Scenario: Calculate Euclidean distance between two 2D vectors
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 4.0 |
+      | 6.0 |
+    When I calculate the Euclidean distance
+    Then the result should be 5.0
+
+  Scenario: Calculate Euclidean distance between identical vectors
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+      | 3.0 |
+    And vector b is
+      | 1.0 |
+      | 2.0 |
+      | 3.0 |
+    When I calculate the Euclidean distance
+    Then the result should be 0.0
+
+  Scenario: Calculate Euclidean distance between 3D vectors
+    Given vector a is
+      | 0.0 |
+      | 0.0 |
+      | 0.0 |
+    And vector b is
+      | 1.0 |
+      | 2.0 |
+      | 2.0 |
+    When I calculate the Euclidean distance
+    Then the result should be 3.0
+
+  Scenario: Calculate Euclidean distance with negative components
+    Given vector a is
+      | -1.0 |
+      | -1.0 |
+    And vector b is
+      | 2.0 |
+      | 3.0 |
+    When I calculate the Euclidean distance
+    Then the result should be 5.0
+
+  Scenario: Calculate Euclidean distance with different length vectors
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 1.0 |
+    When I calculate the Euclidean distance
+    Then the result should be an error

--- a/features/negativeinnerproduct.feature
+++ b/features/negativeinnerproduct.feature
@@ -1,0 +1,55 @@
+Feature: Calculate negative inner product
+  As a developer
+  I want to calculate the negative inner product between vectors
+  So that I can use it as a distance metric
+
+  Scenario: Calculate negative inner product of two positive vectors
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+      | 3.0 |
+    And vector b is
+      | 4.0 |
+      | 5.0 |
+      | 6.0 |
+    When I calculate the negative inner product
+    Then the result should be -32.0
+
+  Scenario: Calculate negative inner product of orthogonal vectors
+    Given vector a is
+      | 1.0 |
+      | 0.0 |
+    And vector b is
+      | 0.0 |
+      | 1.0 |
+    When I calculate the negative inner product
+    Then the result should be 0.0
+
+  Scenario: Calculate negative inner product of identical vectors
+    Given vector a is
+      | 2.0 |
+      | 3.0 |
+    And vector b is
+      | 2.0 |
+      | 3.0 |
+    When I calculate the negative inner product
+    Then the result should be -13.0
+
+  Scenario: Calculate negative inner product with negative components
+    Given vector a is
+      | -1.0 |
+      | 2.0 |
+    And vector b is
+      | 3.0 |
+      | -4.0 |
+    When I calculate the negative inner product
+    Then the result should be 11.0
+
+  Scenario: Calculate negative inner product with different length vectors
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 1.0 |
+    When I calculate the negative inner product
+    Then the result should be an error

--- a/features/taxicabdistance.feature
+++ b/features/taxicabdistance.feature
@@ -1,0 +1,57 @@
+Feature: Calculate taxicab distance
+  As a developer
+  I want to calculate the taxicab distance between vectors
+  So that I can measure the Manhattan distance between points
+
+  Scenario: Calculate taxicab distance between two 2D vectors
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 4.0 |
+      | 6.0 |
+    When I calculate the taxicab distance
+    Then the result should be 7.0
+
+  Scenario: Calculate taxicab distance between identical vectors
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+      | 3.0 |
+    And vector b is
+      | 1.0 |
+      | 2.0 |
+      | 3.0 |
+    When I calculate the taxicab distance
+    Then the result should be 0.0
+
+  Scenario: Calculate taxicab distance between 3D vectors
+    Given vector a is
+      | 0.0 |
+      | 0.0 |
+      | 0.0 |
+    And vector b is
+      | 1.0 |
+      | 2.0 |
+      | 3.0 |
+    When I calculate the taxicab distance
+    Then the result should be 6.0
+
+  Scenario: Calculate taxicab distance with negative components
+    Given vector a is
+      | -1.0 |
+      | -2.0 |
+    And vector b is
+      | 2.0 |
+      | 3.0 |
+    When I calculate the taxicab distance
+    Then the result should be 8.0
+
+  Scenario: Calculate taxicab distance with different length vectors
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 1.0 |
+    When I calculate the taxicab distance
+    Then the result should be an error

--- a/negativeinnerproduct.go
+++ b/negativeinnerproduct.go
@@ -1,0 +1,20 @@
+package vectors
+
+import "errors"
+
+// NegativeInnerProduct calculates the negative inner product (negative dot product) between two vectors.
+// It returns an error if the vectors have different lengths.
+// The negative inner product is: -(Σ(ai * bi))
+// This is commonly used as a distance metric in machine learning.
+func NegativeInnerProduct(a Vector, b Vector) (float64, error) {
+	if len(a) != len(b) {
+		return 0.0, errors.New("vectors must have the same length")
+	}
+
+	sum := 0.0
+	for i := range len(a) {
+		sum += a[i] * b[i]
+	}
+
+	return -sum, nil
+}

--- a/negativeinnerproduct_test.go
+++ b/negativeinnerproduct_test.go
@@ -1,0 +1,28 @@
+package vectors
+
+import (
+	"context"
+	"github.com/cucumber/godog"
+)
+
+func iCalculateTheNegativeInnerProduct(ctx context.Context) (context.Context, error) {
+	a, ok := ctx.Value(aKey{}).(Vector)
+	if !ok {
+		return ctx, nil
+	}
+	b, ok := ctx.Value(bKey{}).(Vector)
+	if !ok {
+		return ctx, nil
+	}
+
+	product, err := NegativeInnerProduct(a, b)
+	if err != nil {
+		return context.WithValue(ctx, errKey{}, err), nil
+	}
+
+	return context.WithValue(ctx, resultKey{}, product), nil
+}
+
+func initializeNegativeInnerProductScenario(ctx *godog.ScenarioContext) {
+	ctx.Step(`^I calculate the negative inner product$`, iCalculateTheNegativeInnerProduct)
+}

--- a/taxicabdistance.go
+++ b/taxicabdistance.go
@@ -1,0 +1,22 @@
+package vectors
+
+import (
+	"errors"
+	"math"
+)
+
+// TaxicabDistance calculates the taxicab distance (Manhattan distance, L1 distance) between two vectors.
+// It returns an error if the vectors have different lengths.
+// The taxicab distance is the sum of absolute differences: Σ|ai - bi|
+func TaxicabDistance(a Vector, b Vector) (float64, error) {
+	if len(a) != len(b) {
+		return 0.0, errors.New("vectors must have the same length")
+	}
+
+	sum := 0.0
+	for i := range len(a) {
+		sum += math.Abs(a[i] - b[i])
+	}
+
+	return sum, nil
+}

--- a/taxicabdistance_test.go
+++ b/taxicabdistance_test.go
@@ -1,0 +1,28 @@
+package vectors
+
+import (
+	"context"
+	"github.com/cucumber/godog"
+)
+
+func iCalculateTheTaxicabDistance(ctx context.Context) (context.Context, error) {
+	a, ok := ctx.Value(aKey{}).(Vector)
+	if !ok {
+		return ctx, nil
+	}
+	b, ok := ctx.Value(bKey{}).(Vector)
+	if !ok {
+		return ctx, nil
+	}
+
+	distance, err := TaxicabDistance(a, b)
+	if err != nil {
+		return context.WithValue(ctx, errKey{}, err), nil
+	}
+
+	return context.WithValue(ctx, resultKey{}, distance), nil
+}
+
+func initializeTaxicabDistanceScenario(ctx *godog.ScenarioContext) {
+	ctx.Step(`^I calculate the taxicab distance$`, iCalculateTheTaxicabDistance)
+}

--- a/vectors_test.go
+++ b/vectors_test.go
@@ -104,6 +104,9 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	initializeIsNormalizedScenario(ctx)
 	initializeEqualsScenario(ctx)
 	initializeMagnitudeScenario(ctx)
+	initializeEuclideanDistanceScenario(ctx)
+	initializeNegativeInnerProductScenario(ctx)
+	initializeTaxicabDistanceScenario(ctx)
 }
 
 func TestFeatures(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds three new distance metric functions for vector calculations:
  - **EuclideanDistance**: Straight-line distance between vectors (L2 norm)
  - **NegativeInnerProduct**: Negative dot product commonly used in ML distance metrics
  - **TaxicabDistance**: Manhattan/L1 distance for axis-aligned movement

- All implementations include comprehensive BDD test coverage (15 new scenarios)
- Each function handles edge cases and validates input (error on mismatched lengths)

## Documentation
- Added **CLAUDE.md**: Development guidance for future Claude Code instances including architecture patterns and BDD testing structure
- Expanded **README.md** with:
  - Complete API reference for all functions
  - Practical usage examples
  - Feature highlights
  - Development setup instructions

## Test plan
- [x] All existing tests pass (20 scenarios)
- [x] 15 new BDD test scenarios added (5 per distance metric)
- [x] Total: 35 scenarios, 115+ steps, all passing
- [x] Test coverage includes:
  - 2D and 3D vectors
  - Identical vectors (zero distance)
  - Orthogonal vectors (where applicable)
  - Negative components
  - Different length vectors (error handling)
- [x] Follows existing codebase patterns and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)