### PR TITLE
Add epsilon-based vector equality comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A lightweight Go library for vector mathematics operations, designed for machine
 - **Euclidean Distance**: Calculate straight-line distance between vectors
 - **Negative Inner Product**: Calculate negative dot product as a distance metric
 - **Taxicab Distance**: Calculate Manhattan/L1 distance between vectors
-- **Equality Checking**: Compare vectors for equality
+- **Equality Checking**: Compare vectors for exact or epsilon-based equality
 - **Normalization Verification**: Check if a vector is already normalized
 - **BDD Test Coverage**: Comprehensive behavioral tests with Cucumber/godog
 
@@ -149,6 +149,47 @@ v3 := vectors.Vector{1.0, 2.0}
 v1.Equals(v2) // Returns true
 v1.Equals(v3) // Returns false (different lengths)
 ```
+
+#### EqualsWithEpsilon
+
+```go
+func (v Vector) EqualsWithEpsilon(other Vector, epsilon float64) bool
+```
+
+Compares two vectors for equality within a specified tolerance. Returns true if the absolute difference between each corresponding component is less than or equal to epsilon. Returns false if vectors have different lengths.
+
+This method is useful for comparing floating-point vectors where exact equality is impractical due to precision limitations.
+
+**Example:**
+```go
+v1 := vectors.Vector{1.0, 2.0, 3.0}
+v2 := vectors.Vector{1.0001, 2.0001, 3.0001}
+
+// Exact comparison fails
+v1.Equals(v2) // Returns false
+
+// Epsilon comparison succeeds
+v1.EqualsWithEpsilon(v2, 0.001) // Returns true
+v1.EqualsWithEpsilon(v2, 0.00001) // Returns false
+
+// Using the default epsilon constant
+v3 := vectors.Vector{1.0, 2.0}
+v4 := vectors.Vector{1.000000001, 2.000000001}
+v3.EqualsWithEpsilon(v4, vectors.DefaultEpsilon) // Returns true
+
+// Different lengths still return false
+v5 := vectors.Vector{1.0, 2.0}
+v6 := vectors.Vector{1.0}
+v5.EqualsWithEpsilon(v6, 0.1) // Returns false
+```
+
+### Constants
+
+```go
+const DefaultEpsilon = 1e-9
+```
+
+The default epsilon value used for floating-point comparisons throughout the library. This constant is used internally by `IsNormalized()` and can be used as a standard tolerance for `EqualsWithEpsilon()`.
 
 ### Functions
 

--- a/equals.go
+++ b/equals.go
@@ -1,11 +1,28 @@
 package vectors
 
+import "math"
+
 func (a Vector) Equals(b Vector) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i, component := range a {
 		if component != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualsWithEpsilon compares two vectors for equality within a specified tolerance.
+// Returns true if the absolute difference between each corresponding component is
+// less than or equal to epsilon. Returns false if vectors have different lengths.
+func (v Vector) EqualsWithEpsilon(other Vector, epsilon float64) bool {
+	if len(v) != len(other) {
+		return false
+	}
+	for i, component := range v {
+		if math.Abs(component-other[i]) > epsilon {
 			return false
 		}
 	}

--- a/equals_test.go
+++ b/equals_test.go
@@ -3,8 +3,12 @@ package vectors
 import (
 	"context"
 	"errors"
+	"strconv"
+
 	"github.com/cucumber/godog"
 )
+
+type epsilonKey struct{}
 
 func iCheckIfVectorsAreEqual(ctx context.Context) (context.Context, error) {
 	a, ok := ctx.Value(aKey{}).(Vector)
@@ -18,6 +22,32 @@ func iCheckIfVectorsAreEqual(ctx context.Context) (context.Context, error) {
 	return context.WithValue(ctx, resultKey{}, a.Equals(b)), nil
 }
 
+func epsilonIs(ctx context.Context, epsilonStr string) (context.Context, error) {
+	epsilon, err := strconv.ParseFloat(epsilonStr, 64)
+	if err != nil {
+		return ctx, err
+	}
+	return context.WithValue(ctx, epsilonKey{}, epsilon), nil
+}
+
+func iCheckIfVectorsAreEqualWithEpsilon(ctx context.Context) (context.Context, error) {
+	a, ok := ctx.Value(aKey{}).(Vector)
+	if !ok {
+		return ctx, errors.New("first arg not found in context")
+	}
+	b, ok := ctx.Value(bKey{}).(Vector)
+	if !ok {
+		return ctx, errors.New("second arg not found in context")
+	}
+	epsilon, ok := ctx.Value(epsilonKey{}).(float64)
+	if !ok {
+		return ctx, errors.New("epsilon not found in context")
+	}
+	return context.WithValue(ctx, resultKey{}, a.EqualsWithEpsilon(b, epsilon)), nil
+}
+
 func initializeEqualsScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I check if vector a equals vector b$`, iCheckIfVectorsAreEqual)
+	ctx.Step(`^epsilon is (\S+)$`, epsilonIs)
+	ctx.Step(`^I check if vector a equals vector b with epsilon$`, iCheckIfVectorsAreEqualWithEpsilon)
 }

--- a/features/equals.feature
+++ b/features/equals.feature
@@ -31,3 +31,68 @@ Feature: Check if vectors are equal
       | 1.0 |
     When I check if vector a equals vector b
     Then the result should be false
+
+  Scenario: Check vectors equal within epsilon tolerance
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 1.0000001 |
+      | 2.0000001 |
+    And epsilon is 0.001
+    When I check if vector a equals vector b with epsilon
+    Then the result should be true
+
+  Scenario: Check vectors not equal outside epsilon tolerance
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 1.1 |
+      | 2.1 |
+    And epsilon is 0.01
+    When I check if vector a equals vector b with epsilon
+    Then the result should be false
+
+  Scenario: Check vectors with epsilon at boundary
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 1.005 |
+      | 2.0 |
+    And epsilon is 0.01
+    When I check if vector a equals vector b with epsilon
+    Then the result should be true
+
+  Scenario: Check vectors with different lengths and epsilon
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 1.0 |
+    And epsilon is 0.001
+    When I check if vector a equals vector b with epsilon
+    Then the result should be false
+
+  Scenario: Check equal vectors with zero epsilon
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 1.0 |
+      | 2.0 |
+    And epsilon is 0.0
+    When I check if vector a equals vector b with epsilon
+    Then the result should be true
+
+  Scenario: Check vectors using DefaultEpsilon constant
+    Given vector a is
+      | 1.0 |
+      | 2.0 |
+    And vector b is
+      | 1.0000000001 |
+      | 2.0000000001 |
+    And epsilon is 1e-9
+    When I check if vector a equals vector b with epsilon
+    Then the result should be true

--- a/isnormalized.go
+++ b/isnormalized.go
@@ -8,5 +8,5 @@ func (v Vector) IsNormalized() bool {
 		sumOfSquares += component * component
 	}
 	length := math.Sqrt(sumOfSquares)
-	return math.Abs(length-1.0) < 1e-9 // Use a small epsilon for floating point comparison
+	return math.Abs(length-1.0) <= DefaultEpsilon
 }

--- a/vector.go
+++ b/vector.go
@@ -1,3 +1,5 @@
 package vectors
 
+const DefaultEpsilon = 1e-9
+
 type Vector []float64


### PR DESCRIPTION
## Summary
- Adds `EqualsWithEpsilon(other Vector, epsilon float64) bool` method for tolerance-based vector equality
- Introduces `DefaultEpsilon` package constant (1e-9) for standard floating-point comparisons
- Refactors `IsNormalized()` to use the new constant for consistency

## Key Features

### EqualsWithEpsilon Method
- Compares vectors component-wise within specified tolerance
- Returns true if `|a[i] - b[i]| <= epsilon` for all components
- Returns false for vectors with different lengths
- Handles floating-point precision issues gracefully

### DefaultEpsilon Constant
```go
const DefaultEpsilon = 1e-9
```
- Standard epsilon value for floating-point comparisons
- Used internally by `IsNormalized()`
- Available for users with `EqualsWithEpsilon()`

### Refactoring
- Updated `IsNormalized()` to use `DefaultEpsilon` instead of hardcoded `1e-9`
- Changed comparison operator from `<` to `<=` for consistency
- Eliminates magic number duplication across the codebase

## Test Coverage
- [x] 6 new BDD test scenarios (all passing)
- [x] Tests cover:
  - Vectors equal within epsilon tolerance
  - Vectors not equal outside epsilon tolerance
  - Boundary cases (floating-point precision handled)
  - Different length vectors (returns false)
  - Zero epsilon (behaves like exact Equals)
  - Using DefaultEpsilon constant
- [x] All existing tests continue to pass (35 scenarios)
- [x] Total: **41 scenarios, 157 steps, 100% passing**

## Documentation
- [x] Complete API documentation in README.md
- [x] Usage examples for all scenarios
- [x] DefaultEpsilon constant documented
- [x] Features list updated

## Technical Notes
- Floating-point precision: Test cases avoid exact boundary values due to IEEE 754 representation
- Error handling: No validation of negative epsilon (follows Go philosophy of trusting caller)
- API design: Receiver method pattern for consistency with existing `Equals()` method

🤖 Generated with [Claude Code](https://claude.com/claude-code)