### PR TITLE
feat: introduce generics supporting float32 and float64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work.sum
 
 #IDEA
 .idea/
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,59 @@ pre-commit run --all-files
 ### Core Design
 This is a Go library providing vector mathematics operations. The architecture follows these principles:
 
-- **Type Definition**: `Vector []float64` - vectors are slices of float64
-- **Receiver Methods**: Operations implemented as methods on the Vector type (e.g., `v.Magnitude()`, `v.Normalize()`)
+- **Generic Type Definition**: `Vec[T Float] []T` - vectors support both float32 and float64
+- **Backward Compatibility**: `Vector = Vec[float64]` - type alias ensures existing code works unchanged
+- **Receiver Methods**: Operations implemented as generic methods on the Vec[T] type (e.g., `v.Magnitude()`, `v.Normalize()`)
+- **Type Preservation**: All operations return the same type as their inputs (e.g., `Vec[float32].Magnitude()` returns `float32`)
 - **Error Handling**: Operations that can fail return `(result, error)` tuples (e.g., `CosineSimilarity` returns error for zero vectors)
 - **BDD Testing**: Comprehensive test coverage using Cucumber/godog with Gherkin feature files
+
+### Working with Generic Types
+
+When adding new operations, follow these patterns:
+
+**Methods** (operate on a single vector or return vector results):
+```go
+func (v Vec[T]) NewMethod() T {
+    sum := T(0)  // Use T(0) instead of 0.0
+    for _, component := range v {
+        sum += component
+    }
+    return sum
+}
+```
+
+**Functions** (operate on multiple vectors):
+```go
+func NewFunction[T Float](a Vec[T], b Vec[T]) (T, error) {
+    if len(a) != len(b) {
+        return T(0), errors.New("vectors must have the same length")
+    }
+    // implementation
+}
+```
+
+**Math Operations** (convert to float64, then back to T):
+```go
+func (v Vec[T]) OperationWithMath() T {
+    value := v.someValue()
+    result := T(math.Sqrt(float64(value)))  // Always convert for math ops
+    return result
+}
+```
+
+**Type-Specific Epsilon**:
+```go
+func (v Vec[T]) IsSpecialProperty() bool {
+    eps := epsilon[T]()  // Gets DefaultEpsilon32 for float32, DefaultEpsilon64 for float64
+    // use eps for comparisons
+}
+```
+
+**Creating New Vectors**:
+```go
+result := make(Vec[T], len(v))  // Use Vec[T], not Vector
+```
 
 ### File Organization Pattern
 Each vector operation follows this structure:
@@ -44,7 +93,7 @@ Each vector operation follows this structure:
 - `features/operation.feature` - Gherkin feature file with test scenarios
 
 Example for the Magnitude operation:
-- `magnitude.go` - Contains `func (v Vector) Magnitude() float64`
+- `magnitude.go` - Contains `func (v Vec[T]) Magnitude() T`
 - `magnitude_test.go` - Contains `iCalculateMagnitudeOfVector()` and `initializeMagnitudeScenario()`
 - `features/magnitude.feature` - Contains BDD test scenarios
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,48 @@ A lightweight Go library for vector mathematics operations, designed for machine
 go get github.com/spandigital/vectors
 ```
 
+## Type Support
+
+The vectors library supports both `float32` and `float64` through Go generics, allowing you to choose between precision and performance/memory efficiency.
+
+### Using float64 (default)
+
+The `Vector` type is an alias for `Vec[float64]` for backward compatibility. Existing code continues to work without modification:
+
+```go
+v := vectors.Vector{3.0, 4.0}  // Uses float64
+magnitude := v.Magnitude()      // Returns float64
+```
+
+### Using float32
+
+For memory efficiency or GPU compatibility, use `Vec[float32]`:
+
+```go
+v := vectors.Vec[float32]{3.0, 4.0}  // Uses float32
+magnitude := v.Magnitude()            // Returns float32
+```
+
+### Type Consistency
+
+All operations preserve the type of their inputs:
+- Methods on `Vec[float32]` return `float32` or `Vec[float32]`
+- Methods on `Vec[float64]` return `float64` or `Vec[float64]`
+- You cannot mix float32 and float64 vectors in operations (compile-time safety)
+
+### Epsilon Values
+
+The library provides type-specific epsilon constants for floating-point comparisons:
+- `DefaultEpsilon64 = 1e-9` for float64 comparisons
+- `DefaultEpsilon32 = 1e-7` for float32 comparisons
+- `DefaultEpsilon` (deprecated) - use `DefaultEpsilon64` instead
+
+```go
+v32 := vectors.Vec[float32]{0.6, 0.8}
+v32Approx := vectors.Vec[float32]{0.6000001, 0.8000001}
+equal := v32.EqualsWithEpsilon(v32Approx, vectors.DefaultEpsilon32)
+```
+
 ## Quick Start
 
 ```go
@@ -91,10 +133,16 @@ func main() {
 ### Type Definition
 
 ```go
-type Vector []float64
+// Generic vector type supporting float32 and float64
+type Vec[T Float] []T
+
+// Backward-compatible alias for float64 vectors
+type Vector = Vec[float64]
 ```
 
-Vector is an alias for a slice of float64 values, representing an n-dimensional vector.
+`Vec[T]` is a generic vector type supporting both `float32` and `float64`, representing an n-dimensional vector with components of type `T`.
+
+`Vector` is a type alias for `Vec[float64]`, maintained for backward compatibility with existing code.
 
 ### Methods
 
@@ -281,10 +329,20 @@ _, err = v7.Subtract(v8) // Returns error
 ### Constants
 
 ```go
-const DefaultEpsilon = 1e-9
+const (
+    DefaultEpsilon64 = 1e-9  // For float64 comparisons
+    DefaultEpsilon32 = 1e-7  // For float32 comparisons
+    DefaultEpsilon   = 1e-9  // Deprecated: Use DefaultEpsilon64
+)
 ```
 
-The default epsilon value used for floating-point comparisons throughout the library. This constant is used internally by `IsNormalized()` and can be used as a standard tolerance for `EqualsWithEpsilon()`.
+Epsilon constants for floating-point comparisons:
+
+- `DefaultEpsilon64`: Default tolerance for float64 comparisons (1e-9). This represents a very small value suitable for 64-bit floating-point precision.
+- `DefaultEpsilon32`: Default tolerance for float32 comparisons (1e-7). This represents a small value suitable for 32-bit floating-point precision.
+- `DefaultEpsilon`: Legacy constant for backward compatibility. New code should use `DefaultEpsilon64` or `DefaultEpsilon32` explicitly.
+
+`IsNormalized()` automatically uses the appropriate epsilon for the vector type. For `EqualsWithEpsilon()`, you can use the type-specific constant that matches your vector type.
 
 ### Functions
 

--- a/arithmetic.go
+++ b/arithmetic.go
@@ -5,12 +5,21 @@ import "errors"
 // Add returns a new vector that is the element-wise sum of v and other.
 // It returns an error if the vectors have different lengths.
 // The result is: result[i] = v[i] + other[i]
-func (v Vector) Add(other Vector) (Vector, error) {
+//
+// This method works with both float32 and float64 vectors,
+// maintaining the same type as the input vectors.
+//
+// Example:
+//
+//	v1 := vectors.Vec[float64]{1.0, 2.0, 3.0}
+//	v2 := vectors.Vec[float64]{4.0, 5.0, 6.0}
+//	sum, err := v1.Add(v2) // Returns Vec[float64]{5.0, 7.0, 9.0}
+func (v Vec[T]) Add(other Vec[T]) (Vec[T], error) {
 	if len(v) != len(other) {
 		return nil, errors.New("vectors must have the same length")
 	}
 
-	result := make(Vector, len(v))
+	result := make(Vec[T], len(v))
 	for i := range len(v) {
 		result[i] = v[i] + other[i]
 	}
@@ -21,12 +30,21 @@ func (v Vector) Add(other Vector) (Vector, error) {
 // Subtract returns a new vector that is the element-wise difference of v and other.
 // It returns an error if the vectors have different lengths.
 // The result is: result[i] = v[i] - other[i]
-func (v Vector) Subtract(other Vector) (Vector, error) {
+//
+// This method works with both float32 and float64 vectors,
+// maintaining the same type as the input vectors.
+//
+// Example:
+//
+//	v1 := vectors.Vec[float64]{5.0, 7.0, 9.0}
+//	v2 := vectors.Vec[float64]{1.0, 2.0, 3.0}
+//	diff, err := v1.Subtract(v2) // Returns Vec[float64]{4.0, 5.0, 6.0}
+func (v Vec[T]) Subtract(other Vec[T]) (Vec[T], error) {
 	if len(v) != len(other) {
 		return nil, errors.New("vectors must have the same length")
 	}
 
-	result := make(Vector, len(v))
+	result := make(Vec[T], len(v))
 	for i := range len(v) {
 		result[i] = v[i] - other[i]
 	}

--- a/cosinesimilarity.go
+++ b/cosinesimilarity.go
@@ -5,7 +5,27 @@ import (
 	"math"
 )
 
-func CosineSimilarity(a Vector, b Vector) (cosine float64, err error) {
+// CosineSimilarity calculates the cosine similarity between two vectors.
+// Returns a value between -1.0 and 1.0, where:
+// - 1.0 indicates identical direction
+// - 0.0 indicates orthogonal vectors
+// - -1.0 indicates opposite direction
+//
+// Returns an error if either vector is a zero vector.
+//
+// Note: This implementation handles vectors of different lengths by treating
+// missing components as zero.
+//
+// This function works with both float32 and float64 vectors,
+// maintaining the same type as the input vectors. Results are returned
+// in the same type as the inputs.
+//
+// Example:
+//
+//	v1 := vectors.Vec[float64]{1.0, 2.0, 3.0}
+//	v2 := vectors.Vec[float64]{4.0, 5.0, 6.0}
+//	similarity, err := vectors.CosineSimilarity(v1, v2) // Returns float64
+func CosineSimilarity[T Float](a Vec[T], b Vec[T]) (cosine T, err error) {
 	count := 0
 	length_a := len(a)
 	length_b := len(b)
@@ -14,24 +34,24 @@ func CosineSimilarity(a Vector, b Vector) (cosine float64, err error) {
 	} else {
 		count = length_b
 	}
-	sumA := 0.0
-	s1 := 0.0
-	s2 := 0.0
+	sumA := T(0)
+	s1 := T(0)
+	s2 := T(0)
 	for k := 0; k < count; k++ {
 		if k >= length_a {
-			s2 += math.Pow(b[k], 2)
+			s2 += T(math.Pow(float64(b[k]), 2))
 			continue
 		}
 		if k >= length_b {
-			s1 += math.Pow(a[k], 2)
+			s1 += T(math.Pow(float64(a[k]), 2))
 			continue
 		}
 		sumA += a[k] * b[k]
-		s1 += math.Pow(a[k], 2)
-		s2 += math.Pow(b[k], 2)
+		s1 += T(math.Pow(float64(a[k]), 2))
+		s2 += T(math.Pow(float64(b[k]), 2))
 	}
 	if s1 == 0 || s2 == 0 {
-		return 0.0, errors.New("vectors should not be null (all zeros)")
+		return T(0), errors.New("vectors should not be null (all zeros)")
 	}
-	return sumA / (math.Sqrt(s1) * math.Sqrt(s2)), nil
+	return sumA / (T(math.Sqrt(float64(s1))) * T(math.Sqrt(float64(s2)))), nil
 }

--- a/dotproduct.go
+++ b/dotproduct.go
@@ -5,12 +5,26 @@ import "errors"
 // DotProduct calculates the dot product (inner product) between two vectors.
 // It returns an error if the vectors have different lengths.
 // The dot product is: Σ(ai * bi)
-func DotProduct(a Vector, b Vector) (float64, error) {
+//
+// This function works with both float32 and float64 vectors,
+// maintaining the same type as the input vectors. Results are returned
+// in the same type as the inputs.
+//
+// Example:
+//
+//	v1 := vectors.Vec[float64]{1.0, 2.0, 3.0}
+//	v2 := vectors.Vec[float64]{4.0, 5.0, 6.0}
+//	product, err := vectors.DotProduct(v1, v2) // Returns float64: 32.0
+//
+//	v3 := vectors.Vec[float32]{1.0, 2.0}
+//	v4 := vectors.Vec[float32]{3.0, 4.0}
+//	product2, err := vectors.DotProduct(v3, v4) // Returns float32: 11.0
+func DotProduct[T Float](a Vec[T], b Vec[T]) (T, error) {
 	if len(a) != len(b) {
-		return 0.0, errors.New("vectors must have the same length")
+		return T(0), errors.New("vectors must have the same length")
 	}
 
-	sum := 0.0
+	sum := T(0)
 	for i := range len(a) {
 		sum += a[i] * b[i]
 	}

--- a/equals.go
+++ b/equals.go
@@ -2,7 +2,17 @@ package vectors
 
 import "math"
 
-func (a Vector) Equals(b Vector) bool {
+// Equals compares two vectors for exact equality.
+// Returns false if vectors have different lengths or any components differ.
+//
+// This method works with both float32 and float64 vectors.
+//
+// Example:
+//
+//	v1 := vectors.Vec[float64]{1.0, 2.0, 3.0}
+//	v2 := vectors.Vec[float64]{1.0, 2.0, 3.0}
+//	equal := v1.Equals(v2) // Returns true
+func (a Vec[T]) Equals(b Vec[T]) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -17,12 +27,25 @@ func (a Vector) Equals(b Vector) bool {
 // EqualsWithEpsilon compares two vectors for equality within a specified tolerance.
 // Returns true if the absolute difference between each corresponding component is
 // less than or equal to epsilon. Returns false if vectors have different lengths.
-func (v Vector) EqualsWithEpsilon(other Vector, epsilon float64) bool {
+//
+// This method works with both float32 and float64 vectors,
+// maintaining the same type as the input vectors.
+//
+// Example:
+//
+//	v1 := vectors.Vec[float64]{1.0, 2.0}
+//	v2 := vectors.Vec[float64]{1.0001, 2.0001}
+//	equal := v1.EqualsWithEpsilon(v2, 0.001) // Returns true
+//
+//	v3 := vectors.Vec[float32]{0.6, 0.8}
+//	v4 := vectors.Vec[float32]{0.6000001, 0.8000001}
+//	equal2 := v3.EqualsWithEpsilon(v4, vectors.DefaultEpsilon32) // Returns true
+func (v Vec[T]) EqualsWithEpsilon(other Vec[T], epsilon T) bool {
 	if len(v) != len(other) {
 		return false
 	}
 	for i, component := range v {
-		if math.Abs(component-other[i]) > epsilon {
+		if T(math.Abs(float64(component-other[i]))) > epsilon {
 			return false
 		}
 	}

--- a/euclideandistance.go
+++ b/euclideandistance.go
@@ -8,16 +8,26 @@ import (
 // EuclideanDistance calculates the Euclidean distance between two vectors.
 // It returns an error if the vectors have different lengths.
 // The Euclidean distance is the straight-line distance between two points: √(Σ(ai - bi)²)
-func EuclideanDistance(a Vector, b Vector) (float64, error) {
+//
+// This function works with both float32 and float64 vectors,
+// maintaining the same type as the input vectors. Results are returned
+// in the same type as the inputs.
+//
+// Example:
+//
+//	v1 := vectors.Vec[float64]{1.0, 2.0}
+//	v2 := vectors.Vec[float64]{4.0, 6.0}
+//	distance, err := vectors.EuclideanDistance(v1, v2) // Returns float64: 5.0
+func EuclideanDistance[T Float](a Vec[T], b Vec[T]) (T, error) {
 	if len(a) != len(b) {
-		return 0.0, errors.New("vectors must have the same length")
+		return T(0), errors.New("vectors must have the same length")
 	}
 
-	sumOfSquares := 0.0
+	sumOfSquares := T(0)
 	for i := range len(a) {
 		diff := a[i] - b[i]
 		sumOfSquares += diff * diff
 	}
 
-	return math.Sqrt(sumOfSquares), nil
+	return T(math.Sqrt(float64(sumOfSquares))), nil
 }

--- a/isnormalized.go
+++ b/isnormalized.go
@@ -2,11 +2,25 @@ package vectors
 
 import "math"
 
-func (v Vector) IsNormalized() bool {
-	sumOfSquares := 0.0
+// IsNormalized checks whether the vector has unit length (magnitude of 1.0).
+// Uses type-appropriate epsilon comparison for floating-point precision
+// (1e-9 for float64, 1e-7 for float32).
+//
+// This method works with both float32 and float64 vectors.
+//
+// Example:
+//
+//	v64 := vectors.Vec[float64]{0.6, 0.8}
+//	isNorm64 := v64.IsNormalized() // Returns true
+//
+//	v32 := vectors.Vec[float32]{0.6, 0.8}
+//	isNorm32 := v32.IsNormalized() // Returns true
+func (v Vec[T]) IsNormalized() bool {
+	sumOfSquares := T(0)
 	for _, component := range v {
 		sumOfSquares += component * component
 	}
-	length := math.Sqrt(sumOfSquares)
-	return math.Abs(length-1.0) <= DefaultEpsilon
+	length := T(math.Sqrt(float64(sumOfSquares)))
+	eps := epsilon[T]()
+	return T(math.Abs(float64(length-1.0))) <= eps
 }

--- a/magnitude.go
+++ b/magnitude.go
@@ -3,10 +3,22 @@ package vectors
 import "math"
 
 // Magnitude returns the length (magnitude) of the vector.
-func (v Vector) Magnitude() float64 {
-	sumOfSquares := 0.0
+//
+// This method works with both float32 and float64 vectors,
+// maintaining the same type as the input vector. Results are returned
+// in the same type as the input.
+//
+// Example:
+//
+//	v64 := vectors.Vec[float64]{3.0, 4.0}
+//	mag64 := v64.Magnitude() // Returns float64: 5.0
+//
+//	v32 := vectors.Vec[float32]{3.0, 4.0}
+//	mag32 := v32.Magnitude() // Returns float32: 5.0
+func (v Vec[T]) Magnitude() T {
+	sumOfSquares := T(0)
 	for _, component := range v {
 		sumOfSquares += component * component
 	}
-	return math.Sqrt(sumOfSquares)
+	return T(math.Sqrt(float64(sumOfSquares)))
 }

--- a/negativeinnerproduct.go
+++ b/negativeinnerproduct.go
@@ -6,12 +6,22 @@ import "errors"
 // It returns an error if the vectors have different lengths.
 // The negative inner product is: -(Σ(ai * bi))
 // This is commonly used as a distance metric in machine learning.
-func NegativeInnerProduct(a Vector, b Vector) (float64, error) {
+//
+// This function works with both float32 and float64 vectors,
+// maintaining the same type as the input vectors. Results are returned
+// in the same type as the inputs.
+//
+// Example:
+//
+//	v1 := vectors.Vec[float64]{1.0, 2.0, 3.0}
+//	v2 := vectors.Vec[float64]{4.0, 5.0, 6.0}
+//	product, err := vectors.NegativeInnerProduct(v1, v2) // Returns float64: -32.0
+func NegativeInnerProduct[T Float](a Vec[T], b Vec[T]) (T, error) {
 	if len(a) != len(b) {
-		return 0.0, errors.New("vectors must have the same length")
+		return T(0), errors.New("vectors must have the same length")
 	}
 
-	sum := 0.0
+	sum := T(0)
 	for i := range len(a) {
 		sum += a[i] * b[i]
 	}

--- a/normalize.go
+++ b/normalize.go
@@ -2,19 +2,32 @@ package vectors
 
 import "math"
 
-func (v Vector) Normalize() Vector {
-	sumOfSquares := 0.0
+// Normalize returns a new vector with the same direction but unit length (magnitude of 1.0).
+// If the vector is a zero vector, it returns the zero vector unchanged.
+//
+// This method works with both float32 and float64 vectors,
+// maintaining the same type as the input vector.
+//
+// Example:
+//
+//	v64 := vectors.Vec[float64]{3.0, 4.0}
+//	norm64 := v64.Normalize() // Returns Vec[float64]{0.6, 0.8}
+//
+//	v32 := vectors.Vec[float32]{3.0, 4.0}
+//	norm32 := v32.Normalize() // Returns Vec[float32]{0.6, 0.8}
+func (v Vec[T]) Normalize() Vec[T] {
+	sumOfSquares := T(0)
 	for _, component := range v {
 		sumOfSquares += component * component
 	}
-	length := math.Sqrt(sumOfSquares)
+	length := T(math.Sqrt(float64(sumOfSquares)))
 
 	// Avoid division by zero if the vector is a zero vector
 	if length == 0 {
 		return v
 	}
 
-	normalizedVector := make(Vector, len(v))
+	normalizedVector := make(Vec[T], len(v))
 	for i, component := range v {
 		normalizedVector[i] = component / length
 	}

--- a/taxicabdistance.go
+++ b/taxicabdistance.go
@@ -8,14 +8,24 @@ import (
 // TaxicabDistance calculates the taxicab distance (Manhattan distance, L1 distance) between two vectors.
 // It returns an error if the vectors have different lengths.
 // The taxicab distance is the sum of absolute differences: Σ|ai - bi|
-func TaxicabDistance(a Vector, b Vector) (float64, error) {
+//
+// This function works with both float32 and float64 vectors,
+// maintaining the same type as the input vectors. Results are returned
+// in the same type as the inputs.
+//
+// Example:
+//
+//	v1 := vectors.Vec[float64]{1.0, 2.0}
+//	v2 := vectors.Vec[float64]{4.0, 6.0}
+//	distance, err := vectors.TaxicabDistance(v1, v2) // Returns float64: 7.0
+func TaxicabDistance[T Float](a Vec[T], b Vec[T]) (T, error) {
 	if len(a) != len(b) {
-		return 0.0, errors.New("vectors must have the same length")
+		return T(0), errors.New("vectors must have the same length")
 	}
 
-	sum := 0.0
+	sum := T(0)
 	for i := range len(a) {
-		sum += math.Abs(a[i] - b[i])
+		sum += T(math.Abs(float64(a[i] - b[i])))
 	}
 
 	return sum, nil

--- a/vector.go
+++ b/vector.go
@@ -1,5 +1,62 @@
 package vectors
 
-const DefaultEpsilon = 1e-9
+// Float is a constraint that permits float32 and float64 types,
+// including named types based on these underlying types.
+type Float interface {
+	~float32 | ~float64
+}
 
-type Vector []float64
+// Vec is a generic vector type representing an n-dimensional vector
+// with components of type T, where T must be a floating-point type.
+//
+// Vec supports both float32 and float64, allowing users to choose
+// between precision (float64) and performance/memory efficiency (float32).
+//
+// All operations on Vec preserve the type of their inputs. For example,
+// Vec[float32].Magnitude() returns float32, not float64.
+//
+// Example:
+//
+//	v64 := vectors.Vec[float64]{3.0, 4.0}
+//	mag64 := v64.Magnitude() // Returns float64: 5.0
+//
+//	v32 := vectors.Vec[float32]{3.0, 4.0}
+//	mag32 := v32.Magnitude() // Returns float32: 5.0
+type Vec[T Float] []T
+
+// Vector is a type alias for backward compatibility with existing code.
+// It represents a vector with float64 components.
+//
+// New code may use Vec[float64] directly or continue using Vector.
+// They are identical types and fully interchangeable.
+type Vector = Vec[float64]
+
+// Epsilon constants for floating-point comparisons.
+const (
+	// DefaultEpsilon64 is the default tolerance for float64 comparisons.
+	// This represents a very small value suitable for 64-bit floating-point precision.
+	DefaultEpsilon64 = 1e-9
+
+	// DefaultEpsilon32 is the default tolerance for float32 comparisons.
+	// This represents a small value suitable for 32-bit floating-point precision.
+	DefaultEpsilon32 = 1e-7
+
+	// DefaultEpsilon is the legacy epsilon constant for backward compatibility.
+	// New code should use DefaultEpsilon64 or DefaultEpsilon32 explicitly.
+	//
+	// Deprecated: Use DefaultEpsilon64 or DefaultEpsilon32 instead.
+	DefaultEpsilon = DefaultEpsilon64
+)
+
+// epsilon returns the appropriate default epsilon for type T.
+// This is a helper function for internal use by operations that need
+// type-specific epsilon values.
+func epsilon[T Float]() T {
+	var zero T
+	switch any(zero).(type) {
+	case float32:
+		return T(DefaultEpsilon32)
+	default: // float64
+		return T(DefaultEpsilon64)
+	}
+}

--- a/vectors_float32_test.go
+++ b/vectors_float32_test.go
@@ -225,7 +225,7 @@ func TestBackwardCompatibility(t *testing.T) {
 	// Test that Vector alias works
 	v := Vector{3.0, 4.0}
 	mag := v.Magnitude()
-	var _ float64 = mag // Should compile - mag is float64
+	var _ float64 = mag //nolint:staticcheck // Intentional: demonstrates mag is float64
 
 	// Test all existing patterns work
 	v2 := Vector{1.0, 2.0}
@@ -233,18 +233,18 @@ func TestBackwardCompatibility(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var _ Vector = sum // Should compile - sum is Vector
+	var _ Vector = sum //nolint:staticcheck // Intentional: demonstrates sum is Vector
 
 	// Test functions work with Vector
 	dot, err := DotProduct(v, v2)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var _ float64 = dot // Should compile - dot is float64
+	var _ float64 = dot //nolint:staticcheck // Intentional: demonstrates dot is float64
 
 	// Test that Vector and Vec[float64] are identical
-	var v3 Vec[float64] = Vector{5.0, 6.0}
-	var v4 Vector = Vec[float64]{7.0, 8.0}
+	var v3 Vec[float64] = Vector{5.0, 6.0}         //nolint:staticcheck // Intentional: demonstrates type compatibility
+	var v4 Vector = Vec[float64]{7.0, 8.0}         //nolint:staticcheck // Intentional: demonstrates type compatibility
 	_, err = v3.Add(v4)
 	if err != nil {
 		t.Fatal(err)

--- a/vectors_float32_test.go
+++ b/vectors_float32_test.go
@@ -1,0 +1,263 @@
+package vectors
+
+import (
+	"math"
+	"testing"
+)
+
+// TestVecFloat32Operations tests basic operations with float32 vectors
+func TestVecFloat32Operations(t *testing.T) {
+	tests := []struct {
+		name string
+		op   func() float32
+		want float32
+	}{
+		{
+			name: "magnitude of 3-4 vector",
+			op: func() float32 {
+				v := Vec[float32]{3.0, 4.0}
+				return v.Magnitude()
+			},
+			want: 5.0,
+		},
+		{
+			name: "dot product",
+			op: func() float32 {
+				v1 := Vec[float32]{1.0, 2.0}
+				v2 := Vec[float32]{3.0, 4.0}
+				result, _ := DotProduct(v1, v2)
+				return result
+			},
+			want: 11.0,
+		},
+		{
+			name: "euclidean distance",
+			op: func() float32 {
+				v1 := Vec[float32]{1.0, 2.0}
+				v2 := Vec[float32]{4.0, 6.0}
+				result, _ := EuclideanDistance(v1, v2)
+				return result
+			},
+			want: 5.0,
+		},
+		{
+			name: "normalize magnitude",
+			op: func() float32 {
+				v := Vec[float32]{3.0, 4.0}
+				normalized := v.Normalize()
+				return normalized.Magnitude()
+			},
+			want: 1.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.op()
+			if math.Abs(float64(got-tt.want)) > DefaultEpsilon32 {
+				t.Errorf("%s = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestVecFloat32VectorOperations tests operations that return vectors
+func TestVecFloat32VectorOperations(t *testing.T) {
+	v1 := Vec[float32]{1.0, 2.0, 3.0}
+	v2 := Vec[float32]{4.0, 5.0, 6.0}
+
+	// Test Add
+	sum, err := v1.Add(v2)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	expected := Vec[float32]{5.0, 7.0, 9.0}
+	for i, val := range sum {
+		if math.Abs(float64(val-expected[i])) > DefaultEpsilon32 {
+			t.Errorf("Add[%d] = %v, want %v", i, val, expected[i])
+		}
+	}
+
+	// Test Subtract
+	diff, err := v2.Subtract(v1)
+	if err != nil {
+		t.Fatalf("Subtract failed: %v", err)
+	}
+	expectedDiff := Vec[float32]{3.0, 3.0, 3.0}
+	for i, val := range diff {
+		if math.Abs(float64(val-expectedDiff[i])) > DefaultEpsilon32 {
+			t.Errorf("Subtract[%d] = %v, want %v", i, val, expectedDiff[i])
+		}
+	}
+
+	// Test Normalize
+	v3 := Vec[float32]{3.0, 4.0}
+	normalized := v3.Normalize()
+	expectedNorm := Vec[float32]{0.6, 0.8}
+	for i, val := range normalized {
+		if math.Abs(float64(val-expectedNorm[i])) > DefaultEpsilon32 {
+			t.Errorf("Normalize[%d] = %v, want %v", i, val, expectedNorm[i])
+		}
+	}
+}
+
+// TestFloat32IsNormalized tests IsNormalized with float32
+func TestFloat32IsNormalized(t *testing.T) {
+	// Normalized vector
+	v1 := Vec[float32]{0.6, 0.8}
+	if !v1.IsNormalized() {
+		t.Error("Expected Vec[float32]{0.6, 0.8} to be normalized")
+	}
+
+	// Non-normalized vector
+	v2 := Vec[float32]{3.0, 4.0}
+	if v2.IsNormalized() {
+		t.Error("Expected Vec[float32]{3.0, 4.0} to not be normalized")
+	}
+
+	// Normalized from Normalize()
+	v3 := Vec[float32]{3.0, 4.0}
+	normalized := v3.Normalize()
+	if !normalized.IsNormalized() {
+		t.Error("Expected normalized vector to pass IsNormalized()")
+	}
+}
+
+// TestFloat32Equals tests equality comparisons with float32
+func TestFloat32Equals(t *testing.T) {
+	v1 := Vec[float32]{1.0, 2.0, 3.0}
+	v2 := Vec[float32]{1.0, 2.0, 3.0}
+	v3 := Vec[float32]{1.0, 2.0}
+
+	if !v1.Equals(v2) {
+		t.Error("Expected identical vectors to be equal")
+	}
+
+	if v1.Equals(v3) {
+		t.Error("Expected vectors of different lengths to not be equal")
+	}
+
+	// Test EqualsWithEpsilon
+	v4 := Vec[float32]{1.0, 2.0}
+	v5 := Vec[float32]{1.00001, 2.00001}
+
+	if !v4.EqualsWithEpsilon(v5, 0.0001) {
+		t.Error("Expected vectors to be equal within epsilon")
+	}
+}
+
+// TestFloat32EdgeCases tests edge cases specific to float32
+func TestFloat32EdgeCases(t *testing.T) {
+	// Test very small values don't underflow to zero
+	v := Vec[float32]{1e-10, 1e-10}
+	mag := v.Magnitude()
+	if mag == 0 {
+		t.Error("Expected non-zero magnitude for small values")
+	}
+
+	// Test zero vector
+	zero := Vec[float32]{0.0, 0.0}
+	normalized := zero.Normalize()
+	if !normalized.Equals(zero) {
+		t.Error("Expected zero vector to normalize to itself")
+	}
+}
+
+// TestFloat32DistanceMetrics tests distance metrics with float32
+func TestFloat32DistanceMetrics(t *testing.T) {
+	v1 := Vec[float32]{1.0, 2.0}
+	v2 := Vec[float32]{4.0, 6.0}
+
+	// Taxicab distance
+	taxicab, err := TaxicabDistance(v1, v2)
+	if err != nil {
+		t.Fatalf("TaxicabDistance failed: %v", err)
+	}
+	if math.Abs(float64(taxicab-7.0)) > DefaultEpsilon32 {
+		t.Errorf("TaxicabDistance = %v, want 7.0", taxicab)
+	}
+
+	// Negative inner product
+	nip, err := NegativeInnerProduct(v1, v2)
+	if err != nil {
+		t.Fatalf("NegativeInnerProduct failed: %v", err)
+	}
+	expectedNip := float32(-16.0) // 1*4 + 2*6 = 4 + 12 = 16, negated = -16
+	if math.Abs(float64(nip-expectedNip)) > DefaultEpsilon32 {
+		t.Errorf("NegativeInnerProduct = %v, want %v", nip, expectedNip)
+	}
+}
+
+// TestFloat32CosineSimilarity tests cosine similarity with float32
+func TestFloat32CosineSimilarity(t *testing.T) {
+	// Identical vectors
+	v1 := Vec[float32]{1.0, 2.0, 3.0}
+	sim, err := CosineSimilarity(v1, v1)
+	if err != nil {
+		t.Fatalf("CosineSimilarity failed: %v", err)
+	}
+	if math.Abs(float64(sim-1.0)) > DefaultEpsilon32 {
+		t.Errorf("CosineSimilarity of identical vectors = %v, want 1.0", sim)
+	}
+
+	// Orthogonal vectors
+	v2 := Vec[float32]{1.0, 0.0}
+	v3 := Vec[float32]{0.0, 1.0}
+	sim2, err := CosineSimilarity(v2, v3)
+	if err != nil {
+		t.Fatalf("CosineSimilarity failed: %v", err)
+	}
+	if math.Abs(float64(sim2)) > DefaultEpsilon32 {
+		t.Errorf("CosineSimilarity of orthogonal vectors = %v, want 0.0", sim2)
+	}
+
+	// Zero vector should return error
+	zero := Vec[float32]{0.0, 0.0}
+	v4 := Vec[float32]{1.0, 2.0}
+	_, err = CosineSimilarity(zero, v4)
+	if err == nil {
+		t.Error("Expected error for zero vector in CosineSimilarity")
+	}
+}
+
+// TestBackwardCompatibility verifies that existing Vector code works unchanged
+func TestBackwardCompatibility(t *testing.T) {
+	// Test that Vector alias works
+	v := Vector{3.0, 4.0}
+	mag := v.Magnitude()
+	var _ float64 = mag // Should compile - mag is float64
+
+	// Test all existing patterns work
+	v2 := Vector{1.0, 2.0}
+	sum, err := v.Add(v2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var _ Vector = sum // Should compile - sum is Vector
+
+	// Test functions work with Vector
+	dot, err := DotProduct(v, v2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var _ float64 = dot // Should compile - dot is float64
+
+	// Test that Vector and Vec[float64] are identical
+	var v3 Vec[float64] = Vector{5.0, 6.0}
+	var v4 Vector = Vec[float64]{7.0, 8.0}
+	_, err = v3.Add(v4)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTypeSafety verifies that type mixing is prevented at compile time
+// Note: These are commented out as they should NOT compile
+// func TestTypeSafety(t *testing.T) {
+// 	v32 := Vec[float32]{1.0, 2.0}
+// 	v64 := Vec[float64]{3.0, 4.0}
+//
+// 	// This should NOT compile:
+// 	// _, _ = v32.Add(v64)  // Cannot mix float32 and float64
+// 	// _, _ = DotProduct(v32, v64)  // Cannot mix types
+// }


### PR DESCRIPTION
## Summary

Introduces generic type support for both `float32` and `float64` while maintaining full backward compatibility with existing code.

### Key Changes

- **Generic Type**: Added `Vec[T Float]` supporting `~float32 | ~float64`
- **Backward Compatible**: `Vector` is now a type alias for `Vec[float64]` - existing code works unchanged
- **Type Preservation**: All operations return the same type as inputs (e.g., `Vec[float32].Magnitude()` returns `float32`)
- **Type-Specific Epsilon**: Added `DefaultEpsilon32` (1e-7) and `DefaultEpsilon64` (1e-9)

### Implementation

**Updated all methods and functions:**
- Methods: `Magnitude()`, `Normalize()`, `IsNormalized()`, `Equals()`, `EqualsWithEpsilon()`, `Add()`, `Subtract()`
- Functions: `DotProduct()`, `CosineSimilarity()`, `EuclideanDistance()`, `NegativeInnerProduct()`, `TaxicabDistance()`

**Documentation:**
- Updated README.md with Type Support section explaining float32/float64 usage
- Updated CLAUDE.md with generic development patterns
- Comprehensive godoc comments on all operations

**Testing:**
- All existing BDD tests pass unchanged (backward compatibility verified)
- Added `vectors_float32_test.go` with comprehensive float32 tests
- Added backward compatibility tests
- All tests pass: `go test ./...` ✅

### Usage Examples

**Existing code continues to work:**
```go
v := vectors.Vector{3.0, 4.0}  // Uses float64
mag := v.Magnitude()            // Returns float64
```

**New float32 support:**
```go
v32 := vectors.Vec[float32]{3.0, 4.0}  // Uses float32
mag32 := v32.Magnitude()                // Returns float32
```

### Verification

- ✅ Build succeeds: `go build -v ./...`
- ✅ All tests pass: `go test ./...`
- ✅ Existing BDD tests unchanged and passing
- ✅ New float32 tests added and passing
- ✅ Backward compatibility verified
- ✅ Type safety: Cannot mix float32 and float64 (compile-time)
- ✅ Documentation updated

## Test Plan

1. Verify existing Vector code works unchanged
2. Test float32 operations (magnitude, dot product, distances)
3. Test normalized vectors with type-appropriate epsilon
4. Verify type safety (mixing types should not compile)
5. Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)